### PR TITLE
Update services endpoint to integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ to add new and/or missing endpoints. Currently, the following services are suppo
 ## Usage
 
 ```go
-import "github.com/xanzy/go-gitlab"
+import "github.com/zkmoney/go-gitlab"
 ```
 
 Construct a new GitLab client, then use the various services on the client to
@@ -144,7 +144,7 @@ package main
 import (
 	"log"
 
-	"github.com/xanzy/go-gitlab"
+	"github.com/zkmoney/go-gitlab"
 )
 
 func main() {

--- a/examples/applications.go
+++ b/examples/applications.go
@@ -19,7 +19,7 @@ package main
 import (
 	"log"
 
-	"github.com/xanzy/go-gitlab"
+	"github.com/zkmoney/go-gitlab"
 )
 
 func applicationsExample() {

--- a/examples/basic_auth.go
+++ b/examples/basic_auth.go
@@ -19,7 +19,7 @@ package main
 import (
 	"log"
 
-	"github.com/xanzy/go-gitlab"
+	"github.com/zkmoney/go-gitlab"
 )
 
 // This example shows how to create a client with username and password.

--- a/examples/impersonation.go
+++ b/examples/impersonation.go
@@ -19,7 +19,7 @@ package main
 import (
 	"log"
 
-	"github.com/xanzy/go-gitlab"
+	"github.com/zkmoney/go-gitlab"
 )
 
 func impersonationExample() {

--- a/examples/labels.go
+++ b/examples/labels.go
@@ -19,7 +19,7 @@ package main
 import (
 	"log"
 
-	"github.com/xanzy/go-gitlab"
+	"github.com/zkmoney/go-gitlab"
 )
 
 func labelExample() {

--- a/examples/languages.go
+++ b/examples/languages.go
@@ -19,7 +19,7 @@ package main
 import (
 	"log"
 
-	"github.com/xanzy/go-gitlab"
+	"github.com/zkmoney/go-gitlab"
 )
 
 func languagesExample() {

--- a/examples/pagination.go
+++ b/examples/pagination.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/xanzy/go-gitlab"
+	"github.com/zkmoney/go-gitlab"
 )
 
 func pagination() {

--- a/examples/pipelines.go
+++ b/examples/pipelines.go
@@ -20,7 +20,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/xanzy/go-gitlab"
+	"github.com/zkmoney/go-gitlab"
 )
 
 func pipelineExample() {

--- a/examples/pipelinestestreport.go
+++ b/examples/pipelinestestreport.go
@@ -19,7 +19,7 @@ package main
 import (
 	"log"
 
-	"github.com/xanzy/go-gitlab"
+	"github.com/zkmoney/go-gitlab"
 )
 
 func pipelineTestReportExample() {

--- a/examples/projects.go
+++ b/examples/projects.go
@@ -19,7 +19,7 @@ package main
 import (
 	"log"
 
-	"github.com/xanzy/go-gitlab"
+	"github.com/zkmoney/go-gitlab"
 )
 
 func projectExample() {

--- a/examples/repository_files.go
+++ b/examples/repository_files.go
@@ -19,7 +19,7 @@ package main
 import (
 	"log"
 
-	"github.com/xanzy/go-gitlab"
+	"github.com/zkmoney/go-gitlab"
 )
 
 func repositoryFileExample() {

--- a/examples/webhook.go
+++ b/examples/webhook.go
@@ -10,7 +10,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/xanzy/go-gitlab"
+	"github.com/zkmoney/go-gitlab"
 )
 
 // webhook is a HTTP Handler for Gitlab Webhook events.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/xanzy/go-gitlab
+module github.com/zkmoney/go-gitlab
 
 require (
 	github.com/google/go-querystring v1.1.0

--- a/services.go
+++ b/services.go
@@ -65,7 +65,7 @@ func (s *ServicesService) ListServices(pid interface{}, options ...RequestOption
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/services", PathEscape(project))
+	u := fmt.Sprintf("projects/%s/integrations", PathEscape(project))
 
 	req, err := s.client.NewRequest(http.MethodGet, u, nil, options)
 	if err != nil {
@@ -109,7 +109,7 @@ func (s *ServicesService) GetCustomIssueTrackerService(pid interface{}, options 
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/services/custom-issue-tracker", PathEscape(project))
+	u := fmt.Sprintf("projects/%s/integrations/custom-issue-tracker", PathEscape(project))
 
 	req, err := s.client.NewRequest(http.MethodGet, u, nil, options)
 	if err != nil {
@@ -148,7 +148,7 @@ func (s *ServicesService) SetCustomIssueTrackerService(pid interface{}, opt *Set
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("projects/%s/services/custom-issue-tracker", PathEscape(project))
+	u := fmt.Sprintf("projects/%s/integrations/custom-issue-tracker", PathEscape(project))
 
 	req, err := s.client.NewRequest(http.MethodPut, u, opt, options)
 	if err != nil {
@@ -167,7 +167,7 @@ func (s *ServicesService) DeleteCustomIssueTrackerService(pid interface{}, optio
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("projects/%s/services/custom-issue-tracker", PathEscape(project))
+	u := fmt.Sprintf("projects/%s/integrations/custom-issue-tracker", PathEscape(project))
 
 	req, err := s.client.NewRequest(http.MethodDelete, u, nil, options)
 	if err != nil {
@@ -205,7 +205,7 @@ func (s *ServicesService) GetDroneCIService(pid interface{}, options ...RequestO
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/services/drone-ci", PathEscape(project))
+	u := fmt.Sprintf("projects/%s/integrations/drone-ci", PathEscape(project))
 
 	req, err := s.client.NewRequest(http.MethodGet, u, nil, options)
 	if err != nil {
@@ -241,7 +241,7 @@ func (s *ServicesService) SetDroneCIService(pid interface{}, opt *SetDroneCIServ
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("projects/%s/services/drone-ci", PathEscape(project))
+	u := fmt.Sprintf("projects/%s/integrations/drone-ci", PathEscape(project))
 
 	req, err := s.client.NewRequest(http.MethodPut, u, opt, options)
 	if err != nil {
@@ -260,7 +260,7 @@ func (s *ServicesService) DeleteDroneCIService(pid interface{}, options ...Reque
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("projects/%s/services/drone-ci", PathEscape(project))
+	u := fmt.Sprintf("projects/%s/integrations/drone-ci", PathEscape(project))
 
 	req, err := s.client.NewRequest(http.MethodDelete, u, nil, options)
 	if err != nil {
@@ -296,7 +296,7 @@ func (s *ServicesService) GetExternalWikiService(pid interface{}, options ...Req
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/services/external-wiki", PathEscape(project))
+	u := fmt.Sprintf("projects/%s/integrations/external-wiki", PathEscape(project))
 
 	req, err := s.client.NewRequest(http.MethodGet, u, nil, options)
 	if err != nil {
@@ -330,7 +330,7 @@ func (s *ServicesService) SetExternalWikiService(pid interface{}, opt *SetExtern
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("projects/%s/services/external-wiki", PathEscape(project))
+	u := fmt.Sprintf("projects/%s/integrations/external-wiki", PathEscape(project))
 
 	req, err := s.client.NewRequest(http.MethodPut, u, opt, options)
 	if err != nil {
@@ -349,7 +349,7 @@ func (s *ServicesService) DeleteExternalWikiService(pid interface{}, options ...
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("projects/%s/services/external-wiki", PathEscape(project))
+	u := fmt.Sprintf("projects/%s/integrations/external-wiki", PathEscape(project))
 
 	req, err := s.client.NewRequest(http.MethodDelete, u, nil, options)
 	if err != nil {
@@ -386,7 +386,7 @@ func (s *ServicesService) GetGithubService(pid interface{}, options ...RequestOp
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/services/github", PathEscape(project))
+	u := fmt.Sprintf("projects/%s/integrations/github", PathEscape(project))
 
 	req, err := s.client.NewRequest(http.MethodGet, u, nil, options)
 	if err != nil {
@@ -422,7 +422,7 @@ func (s *ServicesService) SetGithubService(pid interface{}, opt *SetGithubServic
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("projects/%s/services/github", PathEscape(project))
+	u := fmt.Sprintf("projects/%s/integrations/github", PathEscape(project))
 
 	req, err := s.client.NewRequest(http.MethodPut, u, opt, options)
 	if err != nil {
@@ -441,7 +441,7 @@ func (s *ServicesService) DeleteGithubService(pid interface{}, options ...Reques
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("projects/%s/services/github", PathEscape(project))
+	u := fmt.Sprintf("projects/%s/integrations/github", PathEscape(project))
 
 	req, err := s.client.NewRequest(http.MethodDelete, u, nil, options)
 	if err != nil {
@@ -470,7 +470,7 @@ func (s *ServicesService) SetGitLabCIService(pid interface{}, opt *SetGitLabCISe
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("projects/%s/services/gitlab-ci", PathEscape(project))
+	u := fmt.Sprintf("projects/%s/integrations/gitlab-ci", PathEscape(project))
 
 	req, err := s.client.NewRequest(http.MethodPut, u, opt, options)
 	if err != nil {
@@ -489,7 +489,7 @@ func (s *ServicesService) DeleteGitLabCIService(pid interface{}, options ...Requ
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("projects/%s/services/gitlab-ci", PathEscape(project))
+	u := fmt.Sprintf("projects/%s/integrations/gitlab-ci", PathEscape(project))
 
 	req, err := s.client.NewRequest(http.MethodDelete, u, nil, options)
 	if err != nil {
@@ -518,7 +518,7 @@ func (s *ServicesService) SetHipChatService(pid interface{}, opt *SetHipChatServ
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("projects/%s/services/hipchat", PathEscape(project))
+	u := fmt.Sprintf("projects/%s/integrations/hipchat", PathEscape(project))
 
 	req, err := s.client.NewRequest(http.MethodPut, u, opt, options)
 	if err != nil {
@@ -537,7 +537,7 @@ func (s *ServicesService) DeleteHipChatService(pid interface{}, options ...Reque
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("projects/%s/services/hipchat", PathEscape(project))
+	u := fmt.Sprintf("projects/%s/integrations/hipchat", PathEscape(project))
 
 	req, err := s.client.NewRequest(http.MethodDelete, u, nil, options)
 	if err != nil {
@@ -575,7 +575,7 @@ func (s *ServicesService) GetJenkinsCIService(pid interface{}, options ...Reques
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/services/jenkins", PathEscape(project))
+	u := fmt.Sprintf("projects/%s/integrations/jenkins", PathEscape(project))
 
 	req, err := s.client.NewRequest(http.MethodGet, u, nil, options)
 	if err != nil {
@@ -615,7 +615,7 @@ func (s *ServicesService) SetJenkinsCIService(pid interface{}, opt *SetJenkinsCI
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("projects/%s/services/jenkins", PathEscape(project))
+	u := fmt.Sprintf("projects/%s/integrations/jenkins", PathEscape(project))
 
 	req, err := s.client.NewRequest(http.MethodPut, u, opt, options)
 	if err != nil {
@@ -634,7 +634,7 @@ func (s *ServicesService) DeleteJenkinsCIService(pid interface{}, options ...Req
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("projects/%s/services/jenkins", PathEscape(project))
+	u := fmt.Sprintf("projects/%s/integrations/jenkins", PathEscape(project))
 
 	req, err := s.client.NewRequest(http.MethodDelete, u, nil, options)
 	if err != nil {
@@ -705,7 +705,7 @@ func (s *ServicesService) GetJiraService(pid interface{}, options ...RequestOpti
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/services/jira", PathEscape(project))
+	u := fmt.Sprintf("projects/%s/integrations/jira", PathEscape(project))
 
 	req, err := s.client.NewRequest(http.MethodGet, u, nil, options)
 	if err != nil {
@@ -748,7 +748,7 @@ func (s *ServicesService) SetJiraService(pid interface{}, opt *SetJiraServiceOpt
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("projects/%s/services/jira", PathEscape(project))
+	u := fmt.Sprintf("projects/%s/integrations/jira", PathEscape(project))
 
 	req, err := s.client.NewRequest(http.MethodPut, u, opt, options)
 	if err != nil {
@@ -767,7 +767,7 @@ func (s *ServicesService) DeleteJiraService(pid interface{}, options ...RequestO
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("projects/%s/services/jira", PathEscape(project))
+	u := fmt.Sprintf("projects/%s/integrations/jira", PathEscape(project))
 
 	req, err := s.client.NewRequest(http.MethodDelete, u, nil, options)
 	if err != nil {
@@ -816,7 +816,7 @@ func (s *ServicesService) GetMattermostService(pid interface{}, options ...Reque
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/services/mattermost", PathEscape(project))
+	u := fmt.Sprintf("projects/%s/integrations/mattermost", PathEscape(project))
 
 	req, err := s.client.NewRequest(http.MethodGet, u, nil, options)
 	if err != nil {
@@ -872,7 +872,7 @@ func (s *ServicesService) SetMattermostService(pid interface{}, opt *SetMattermo
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("projects/%s/services/mattermost", PathEscape(project))
+	u := fmt.Sprintf("projects/%s/integrations/mattermost", PathEscape(project))
 
 	req, err := s.client.NewRequest(http.MethodPut, u, opt, options)
 	if err != nil {
@@ -891,7 +891,7 @@ func (s *ServicesService) DeleteMattermostService(pid interface{}, options ...Re
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("projects/%s/services/mattermost", PathEscape(project))
+	u := fmt.Sprintf("projects/%s/integrations/mattermost", PathEscape(project))
 
 	req, err := s.client.NewRequest(http.MethodDelete, u, nil, options)
 	if err != nil {
@@ -937,7 +937,7 @@ func (s *ServicesService) GetMicrosoftTeamsService(pid interface{}, options ...R
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/services/microsoft-teams", PathEscape(project))
+	u := fmt.Sprintf("projects/%s/integrations/microsoft-teams", PathEscape(project))
 
 	req, err := s.client.NewRequest(http.MethodGet, u, nil, options)
 	if err != nil {
@@ -982,7 +982,7 @@ func (s *ServicesService) SetMicrosoftTeamsService(pid interface{}, opt *SetMicr
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("projects/%s/services/microsoft-teams", PathEscape(project))
+	u := fmt.Sprintf("projects/%s/integrations/microsoft-teams", PathEscape(project))
 
 	req, err := s.client.NewRequest(http.MethodPut, u, opt, options)
 	if err != nil {
@@ -1000,7 +1000,7 @@ func (s *ServicesService) DeleteMicrosoftTeamsService(pid interface{}, options .
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("projects/%s/services/microsoft-teams", PathEscape(project))
+	u := fmt.Sprintf("projects/%s/integrations/microsoft-teams", PathEscape(project))
 
 	req, err := s.client.NewRequest(http.MethodDelete, u, nil, options)
 	if err != nil {
@@ -1039,7 +1039,7 @@ func (s *ServicesService) GetPipelinesEmailService(pid interface{}, options ...R
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/services/pipelines-email", PathEscape(project))
+	u := fmt.Sprintf("projects/%s/integrations/pipelines-email", PathEscape(project))
 
 	req, err := s.client.NewRequest(http.MethodGet, u, nil, options)
 	if err != nil {
@@ -1078,7 +1078,7 @@ func (s *ServicesService) SetPipelinesEmailService(pid interface{}, opt *SetPipe
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("projects/%s/services/pipelines-email", PathEscape(project))
+	u := fmt.Sprintf("projects/%s/integrations/pipelines-email", PathEscape(project))
 
 	req, err := s.client.NewRequest(http.MethodPut, u, opt, options)
 	if err != nil {
@@ -1097,7 +1097,7 @@ func (s *ServicesService) DeletePipelinesEmailService(pid interface{}, options .
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("projects/%s/services/pipelines-email", PathEscape(project))
+	u := fmt.Sprintf("projects/%s/integrations/pipelines-email", PathEscape(project))
 
 	req, err := s.client.NewRequest(http.MethodDelete, u, nil, options)
 	if err != nil {
@@ -1135,7 +1135,7 @@ func (s *ServicesService) GetPrometheusService(pid interface{}, options ...Reque
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/services/prometheus", PathEscape(project))
+	u := fmt.Sprintf("projects/%s/integrations/prometheus", PathEscape(project))
 
 	req, err := s.client.NewRequest(http.MethodGet, u, nil, options)
 	if err != nil {
@@ -1171,7 +1171,7 @@ func (s *ServicesService) SetPrometheusService(pid interface{}, opt *SetPromethe
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("projects/%s/services/prometheus", PathEscape(project))
+	u := fmt.Sprintf("projects/%s/integrations/prometheus", PathEscape(project))
 
 	req, err := s.client.NewRequest(http.MethodPut, u, opt, options)
 	if err != nil {
@@ -1190,7 +1190,7 @@ func (s *ServicesService) DeletePrometheusService(pid interface{}, options ...Re
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("projects/%s/services/prometheus", PathEscape(project))
+	u := fmt.Sprintf("projects/%s/integrations/prometheus", PathEscape(project))
 
 	req, err := s.client.NewRequest(http.MethodDelete, u, nil, options)
 	if err != nil {
@@ -1241,7 +1241,7 @@ func (s *ServicesService) GetSlackService(pid interface{}, options ...RequestOpt
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/services/slack", PathEscape(project))
+	u := fmt.Sprintf("projects/%s/integrations/slack", PathEscape(project))
 
 	req, err := s.client.NewRequest(http.MethodGet, u, nil, options)
 	if err != nil {
@@ -1303,7 +1303,7 @@ func (s *ServicesService) SetSlackService(pid interface{}, opt *SetSlackServiceO
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("projects/%s/services/slack", PathEscape(project))
+	u := fmt.Sprintf("projects/%s/integrations/slack", PathEscape(project))
 
 	req, err := s.client.NewRequest(http.MethodPut, u, opt, options)
 	if err != nil {
@@ -1322,7 +1322,7 @@ func (s *ServicesService) DeleteSlackService(pid interface{}, options ...Request
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("projects/%s/services/slack", PathEscape(project))
+	u := fmt.Sprintf("projects/%s/integrations/slack", PathEscape(project))
 
 	req, err := s.client.NewRequest(http.MethodDelete, u, nil, options)
 	if err != nil {
@@ -1358,7 +1358,7 @@ func (s *ServicesService) GetSlackSlashCommandsService(pid interface{}, options 
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/services/slack-slash-commands", PathEscape(project))
+	u := fmt.Sprintf("projects/%s/integrations/slack-slash-commands", PathEscape(project))
 
 	req, err := s.client.NewRequest(http.MethodGet, u, nil, options)
 	if err != nil {
@@ -1392,7 +1392,7 @@ func (s *ServicesService) SetSlackSlashCommandsService(pid interface{}, opt *Set
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("projects/%s/services/slack-slash-commands", PathEscape(project))
+	u := fmt.Sprintf("projects/%s/integrations/slack-slash-commands", PathEscape(project))
 
 	req, err := s.client.NewRequest(http.MethodPut, u, opt, options)
 	if err != nil {
@@ -1411,7 +1411,7 @@ func (s *ServicesService) DeleteSlackSlashCommandsService(pid interface{}, optio
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("projects/%s/services/slack-slash-commands", PathEscape(project))
+	u := fmt.Sprintf("projects/%s/integrations/slack-slash-commands", PathEscape(project))
 
 	req, err := s.client.NewRequest(http.MethodDelete, u, nil, options)
 	if err != nil {
@@ -1450,7 +1450,7 @@ func (s *ServicesService) GetYouTrackService(pid interface{}, options ...Request
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/services/youtrack", PathEscape(project))
+	u := fmt.Sprintf("projects/%s/integrations/youtrack", PathEscape(project))
 
 	req, err := s.client.NewRequest(http.MethodGet, u, nil, options)
 	if err != nil {
@@ -1487,7 +1487,7 @@ func (s *ServicesService) SetYouTrackService(pid interface{}, opt *SetYouTrackSe
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("projects/%s/services/youtrack", PathEscape(project))
+	u := fmt.Sprintf("projects/%s/integrations/youtrack", PathEscape(project))
 
 	req, err := s.client.NewRequest(http.MethodPut, u, opt, options)
 	if err != nil {
@@ -1506,7 +1506,7 @@ func (s *ServicesService) DeleteYouTrackService(pid interface{}, options ...Requ
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("projects/%s/services/youtrack", PathEscape(project))
+	u := fmt.Sprintf("projects/%s/integrations/youtrack", PathEscape(project))
 
 	req, err := s.client.NewRequest(http.MethodDelete, u, nil, options)
 	if err != nil {


### PR DESCRIPTION
As of Gitlab 14.4 the services endpoint has been renamed
integrations.

'https://docs.gitlab.com/ee/api/integrations.html'